### PR TITLE
Support of ActionMailer sender name format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Add follow code to application_mailer
   self.unione_settings = Rails.application.secrets.unione
 ```
 
+Use ActionMailer sender name format:
+
+```ruby
+mail to: 'bill@microsoft.com', subject: 'I like you!', from: 'Tim Cook <tim@apple.com>'
+```
+
+in this case Unisender will send email as Tim Cook in the name field.
 
 ## Development
 

--- a/lib/unione/sender.rb
+++ b/lib/unione/sender.rb
@@ -48,7 +48,7 @@ module Unione
         message: {
           subject: mail.subject,
           from_email: mail.from.first,
-          from_name: @settings[:sender_name] || mail.from.split('@').first,
+          from_name: sender_name(mail.From.unparsed_value),
           recipients: recipients,
           body: { html: mail_body },
           inline_attachments: inline_attachments
@@ -106,6 +106,17 @@ module Unione
 
       @logger.info "--- UNIONE: response = #{result.inspect} ---"
       result
+    end
+
+    def sender_name(mail_from)
+      # ActionMailer::Base default sender form `Bill Gates <bill@microsoft.com>`
+      
+      default_mail_form_regexp = / <[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z0-9]+>/ 
+      if mail_from.match default_mail_form_regexp
+        mail_from.sub default_mail_form_regexp, ''
+      else
+        @settings[:sender_name] || mail_from.split('@').first
+      end
     end
   end
 end


### PR DESCRIPTION
Now, we can use `Tim Cook <tim@apple.com>` as `from` argument.

In this case Unisender will send email as Tim Cook in the name field